### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This addon provides SFTP storage support for BlueMap.
    - Get the latest version of the addon from the [releases page](../../releases/latest).
 
 2. **Install the AddOn**
-   - Place the downloaded `BlueMapSshStorage-{version}.jar` file into the `addons` folder located next to your BlueMap configuration files.
+   - Place the downloaded `BlueMapSshStorage-{version}.jar` file into the `packs` folder located next to your BlueMap configuration files, it should look like `BlueMap/packs/letsmine-bluemap-0.3.jar`.
 
 3. **Configure SFTP**
    - Copy the [sftp.conf](./src/main/resources/sftp.conf) file to the `storage` folder located next to your BlueMap configuration files.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This addon provides SFTP storage support for BlueMap.
    - Get the latest version of the addon from the [releases page](../../releases/latest).
 
 2. **Install the AddOn**
-   - Place the downloaded `BlueMapSshStorage-{version}.jar` file into the `packs` folder located next to your BlueMap configuration files, it should look like `BlueMap/packs/letsmine-bluemap-0.3.jar`.
+   - Place the downloaded `BlueMapSshStorage-{version}.jar` file into the `packs` folder located next to your BlueMap configuration files, it should look like `BlueMap/packs/letsmine-bluemap-{version}.jar`.
 
 3. **Configure SFTP**
    - Copy the [sftp.conf](./src/main/resources/sftp.conf) file to the `storage` folder located next to your BlueMap configuration files.


### PR DESCRIPTION
This pull request updates the installation instructions in the `README.md` file to reflect changes in the folder structure where the addon file should be placed.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11-R11): Updated the installation instructions to specify that the `BlueMapSshStorage-{version}.jar` file should now be placed in the `packs` folder instead of the `addons` folder. Additionally, clarified the expected file path format for better user understanding.